### PR TITLE
Code_alias

### DIFF
--- a/.zsh_aliases
+++ b/.zsh_aliases
@@ -2,7 +2,7 @@
 # General aliases
 ##################
 #alias subl="'/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl'"
-alias code='/opt/homebrew/bin/codium'
+alias code='open -a VSCodium'
 alias grep="grep --colour --devices=skip"
 alias history='history -E'
 alias hist='history -E 1'


### PR DESCRIPTION
Change the `code` alias to use open instead of running the binary directly. 